### PR TITLE
feat: Calculate the scale dynamically in the screenshot view

### DIFF
--- a/src/components/snapshot/TimeTableSnapshot1Col.tsx
+++ b/src/components/snapshot/TimeTableSnapshot1Col.tsx
@@ -205,6 +205,8 @@ export default function TimeTableSnapshot({ schedule, selectedDay, artists, capt
 							return null;
 						}
 
+						// Calculate column start and end times,
+						// it start from the FIRST artist and end at the LAST artist.
 						const columnStartTime = artists[0]._start;
 						const columnEndTime = artists.reduce(
 							(latest, artist) => (artist._end > latest ? artist._end : latest),
@@ -212,6 +214,7 @@ export default function TimeTableSnapshot({ schedule, selectedDay, artists, capt
 						);
 						const columnDuration = differenceInMinutes(columnEndTime, columnStartTime);
 
+						// Generate the scale ticks on the left side of the screen.
 						const scaleTicks = [];
 						if (artists.length > 0) {
 							const currentMinutes = getMinutes(columnStartTime);


### PR DESCRIPTION
We used to set a fix value for the scale, like `1.2rem`.
However, it's no suitable for every screen size.
So we change to set the scale dynamically, by using the **start time** of the 1st artist and the **end time** of the last artist,  and then calculating the percentage.